### PR TITLE
fix: Replace 'uname' for download process to work on rpi5 machines.

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -97,7 +97,7 @@ if [ "$found_mono" == "yes" ]; then
 fi
 
 if [ "$platform" == "linux" ]; then
-	arch=$(dpkg-architecture -qDEB_BUILD_ARCH)
+	arch=$(normalize_arch)
 	base_name="Godot_v${base_version}_${install_platform}"
 	extracted_bin_name="${base_name}.${arch}"
 	if [ "$found_mono" == "yes" ]; then

--- a/bin/download
+++ b/bin/download
@@ -97,7 +97,7 @@ if [ "$found_mono" == "yes" ]; then
 fi
 
 if [ "$platform" == "linux" ]; then
-	arch=$(uname -m)
+	arch=$(dpkg-architecture -qDEB_BUILD_ARCH)
 	base_name="Godot_v${base_version}_${install_platform}"
 	extracted_bin_name="${base_name}.${arch}"
 	if [ "$found_mono" == "yes" ]; then

--- a/lib/asdf-godot.bash
+++ b/lib/asdf-godot.bash
@@ -117,7 +117,7 @@ get_download_filename() {
 	version="$1"
 
 	platform=$(uname | tr '[:upper:]' '[:lower:]')
-	arch=$(uname -m)
+	arch=$(dpkg-architecture -qDEB_BUILD_ARCH)
 	join_char="."
 
 	if [ "${platform}" == 'darwin' ]; then

--- a/lib/asdf-godot.bash
+++ b/lib/asdf-godot.bash
@@ -82,6 +82,19 @@ sort_versions() {
   ' | LC_ALL=C sort -t'|' -k1,1 | awk -F'|' '{print $2}'
 }
 
+normalize_arch() {
+	local arch
+	arch=$(uname -m)
+
+	if [ "$arch" = "aarch64" ]; then
+		arch="arm64"
+	elif [ "$arch" = "armv71" ]; then
+		arch="arm32"
+	fi
+
+	echo "$arch"
+}
+
 # Get tags from the official Godot Engine GitHub repository
 list_stable_github_tags() {
 	git ls-remote --tags --refs "$GODOT_STABLE_REPO" |
@@ -117,7 +130,7 @@ get_download_filename() {
 	version="$1"
 
 	platform=$(uname | tr '[:upper:]' '[:lower:]')
-	arch=$(dpkg-architecture -qDEB_BUILD_ARCH)
+	arch=$(normalize_arch)
 	join_char="."
 
 	if [ "${platform}" == 'darwin' ]; then


### PR DESCRIPTION
In relation to this issue: https://github.com/mkungla/asdf-godot/issues/11#issue-3873575135